### PR TITLE
Fix export port to 8000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,5 @@ USER root
 RUN chown -R user:user $HOME/app
 USER user
 
-EXPOSE 7860
-
+EXPOSE 8000
 CMD ["python3", "-u", "app_multispeaker_e2e.py"]


### PR DESCRIPTION
TEST: manual test
docker build -t minimal-tts-multispeaker-api .
docker run -p 8888:8000 -t minimal-tts-multispeaker-api &
curl -X POST   http://0.0.0.0:8888/api/tts   -H "Content-Type: application/json"   -d '{"text":"Bon dia.","voice":20,"type":"text"}'   | aplay -t wav -
